### PR TITLE
Enhance walker

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,23 @@ walk(window, (value, path) => {
 
 // options object can be passed as third argument optionally:
 const opts = {
-    limit: 3, // recursive depth
-    key: (k) => '__' + k + '__', // customize keys that construct the path
+    // a function with which the visited keys during walking 
+    // process can be customizd for how they appear within 
+    // @path argument (useful for aggregation purposes).
+    generateKey, // (k) => '__' + k + '__'
+    // a boolean to indicate whether to use or avoid cache for visited values.
+    // when true, walker will not skip walking into non primitive values that were already processed.
+    avoidValuesCache, // true/false [default false]
+    // a Set when prefered providing your own cache Set when @avoidValuesCache is set to false.
+    // useful when running multiple walkers in a single execution.
+    valuesCacheSet, // new Set()
+    // a boolean to indicate whether to use or avoid cache for visited properties.
+    // when true, walker will not avoid generating own properties of objects to walk into more than once.
+    avoidPropertiesCache, // true/false [default false]
+    // a Map when prefered providing your own cache Map when @avoidPropertiesCache is set to false.
+    // useful when running multiple walkers in a single execution.
+    propertiesCacheMap, // new Map()
+    // a number to indicate the maximum recursion depth walker is allowed to walk.
+    maxRecursionLimit, // 3 [default 5]
 };
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lavamoat/walker",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "walker",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const walk = require('./walk');
 
 module.exports = function(start, cb, opts = {}) {
     if (typeof cb !== 'function') {
-        throw new Error(`@options.cb must be a function, instead got a "${typeof cb}"`);
+        throw new Error(`@cb must be a function, instead got a "${typeof cb}"`);
     }
     return walk(start, cb, opts);
 };

--- a/src/options.js
+++ b/src/options.js
@@ -1,9 +1,19 @@
 function options(opts = {}) {
-    if (typeof opts.key !== 'function') {
-        opts.key = (prop, val) => `${({}).toString.call(val)}:${prop}`;
+    if (typeof opts.generateKey !== 'function') {
+        opts.generateKey = (prop, val) => `${({}).toString.call(val)}:${prop}`;
     }
-    if (typeof opts.limit !== 'number') {
-        opts.limit = 5;
+    if (typeof opts.maxRecursionLimit !== 'number') {
+        opts.maxRecursionLimit = 5;
+    }
+    if (!(opts.avoidPropertiesCache = Boolean(opts.avoidPropertiesCache))) {
+        if (typeof opts.propertiesCacheMap !== 'object') {
+            opts.propertiesCacheMap = new Map();
+        }
+    }
+    if (!(opts.avoidValuesCache = Boolean(opts.avoidValuesCache))) {
+        if (typeof opts.valuesCacheSet !== 'object') {
+            opts.valuesCacheSet = new Set();
+        }
     }
     return opts;
 }

--- a/src/properties.js
+++ b/src/properties.js
@@ -1,6 +1,7 @@
-const cache = new Map();
-
-function getAllPropsFromCache(obj) {
+function getAllPropsFromCache(obj, cache) {
+    if (!cache) {
+        return Object.getOwnPropertyNames(obj);
+    }
     let ownProps = cache.get(obj);
     if (!ownProps) {
         ownProps = Object.getOwnPropertyNames(obj);
@@ -9,12 +10,12 @@ function getAllPropsFromCache(obj) {
     return ownProps;
 }
 
-function getAllProps(obj, props = []) {
+function getAllProps(obj, cache, props = []) {
     if (!obj) {
         return props;
     }
-    props = [...props, ...getAllPropsFromCache(obj)];
-    return getAllProps(Object.getPrototypeOf(obj), props);
+    props = [...props, ...getAllPropsFromCache(obj, cache)];
+    return getAllProps(Object.getPrototypeOf(obj), cache, props);
 }
 
 module.exports = getAllProps;


### PR DESCRIPTION
Major enhancements (breaking 0.0.2 -> 0.1.0):
* Walker ignored walking into `function`s  - fixed.
* Walking into `function`s introduced new errors:
  * `WebAssembly` properties access through prototype instead of instance throw unique error messages - dealt with.
  * Handle specific new error when trying to access `Function` strict mode props.
* Rename all optional configurations and allow providing caches as config instead of using inner ones.