### PR TITLE
Support should ignore onerror callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ const opts = {
     // process can be customizd for how they appear within 
     // @path argument (useful for aggregation purposes).
     generateKey, // (k) => '__' + k + '__'
+    // a function that catches errors thrown in the function that is trying to determine
+    // whether a property of an object should be ignored from walking into or not.
+    // since it is very delicate, the user can catch those errors and decide how to deal with them.
+    // use it to return true to skip the property or false to try to walk into it.
+    onShouldIgnoreError, // (prop, obj, error) => true <-- this will skip properties that failed the ignore-check
     // a boolean to indicate whether to use or avoid cache for visited values.
     // when true, walker will not skip walking into non primitive values that were already processed.
     avoidValuesCache, // true/false [default false]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lavamoat/walker",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "walker",
   "main": "src/index.js",
   "repository": {

--- a/src/ignores.js
+++ b/src/ignores.js
@@ -58,12 +58,16 @@ function shouldIgnoreSvgLengthValue(prop, obj, values) {
     return true;
 }
 
-function shouldIgnore(prop, obj, values) {
-    return (
-        shouldIgnoreAsyncProps(prop, obj) ||
-        shouldIgnoreSvgLengthValue(prop, obj, values) ||
-        shouldIgnoreProtoProperty(prop, obj)
-    );
+function shouldIgnore(prop, obj, values, onerror) {
+    try {
+        return (
+            shouldIgnoreAsyncProps(prop, obj) ||
+            shouldIgnoreSvgLengthValue(prop, obj, values) ||
+            shouldIgnoreProtoProperty(prop, obj)
+        );
+    } catch (error) {
+        return onerror(prop, obj, error);
+    }
 }
 
 module.exports = shouldIgnore;

--- a/src/walker.js
+++ b/src/walker.js
@@ -40,7 +40,7 @@ Walker.prototype.walkRecursively = function(obj, limit, keys = [], values = []) 
     const props = getAllProps(obj, cache);
     for (let i = 0; i < props.length; i++) {
         const prop = props[i];
-        if (shouldIgnore(prop, obj, values)) {
+        if (shouldIgnore(prop, obj, values, this.onShouldIgnoreError)) {
             continue;
         }
         const val = obj[prop];
@@ -55,6 +55,7 @@ Walker.prototype.walkRecursively = function(obj, limit, keys = [], values = []) 
 
 function Walker(cb, {
                     generateKey,
+                    onShouldIgnoreError,
                     avoidValuesCache,
                     avoidPropertiesCache,
                     valuesCacheSet,
@@ -66,6 +67,9 @@ function Walker(cb, {
     }
     if (typeof generateKey !== 'function') {
         generateKey = (prop, val) => `${({}).toString.call(val)}:${prop}`;
+    }
+    if (typeof onShouldIgnoreError !== 'function') {
+        onShouldIgnoreError = (prop, obj, error) => { throw error };
     }
     if (typeof maxRecursionLimit !== 'number') {
         maxRecursionLimit = 5;
@@ -82,6 +86,7 @@ function Walker(cb, {
     }
     this.cb = cb;
     this.generateKey = generateKey;
+    this.onShouldIgnoreError = onShouldIgnoreError;
     this.avoidValuesCache = avoidValuesCache;
     this.avoidPropertiesCache = avoidPropertiesCache;
     this.valuesCacheSet = valuesCacheSet;


### PR DESCRIPTION
Taming all possible ways for a property access to throw error seems to be impossible. Therefore it should be the user's decision whether and which properties to ignore if an error is thrown instead of just throwing the error (default behaviour remains throwing the error).